### PR TITLE
Неверный sha256sum у geosite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
           install -p {antifilter-download,antifilter-download-community,refilter,win-spy,win-update,win-extra}.txt ./publish/
           install -p ./custom/publish/{ru-blocked,ru-blocked-all,discord,youtube,google,private,category-ads-all}.txt ./publish/
           
-          sha256sum ./publish/geosite.dat > ./publish/geosite.dat.sha256sum
+          (cd ./publish && sha256sum geosite.dat > geosite.dat.sha256sum)
 
       - name: Release and upload assets
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
При проверке sha выпадает ошибка

У файла на конце неверный путь ./publish/geosite.dat

total 80676
drwx------ 2 root root     4096 Feb 13 15:56 .
drwxrwxrwt 9 root root     4096 Feb 13 15:56 ..
-rw-r--r-- 1 root root 21570425 Feb 13 15:56 geoip.dat
-rw-r--r-- 1 root root       76 Feb 13 15:56 geoip.dat.sha256sum
-rw-r--r-- 1 root root 61018705 Feb 13 15:56 geosite.dat
-rw-r--r-- 1 root root       88 Feb 13 15:56 geosite.dat.sha256sum
geoip.dat: OK
sha256sum: ./publish/geosite.dat: No such file or directory
./publish/geosite.dat: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read

